### PR TITLE
Update installments generator options and add a new utility function for determining the generator options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.6
+
+### Features
+* Added new default option to the installments generator to determine the maximum number of installments.
+* Added new `determineInstallmentGeneratorOptions` utility function for determining the installments generator options, outside of the wrapper or plugin scripts.
+
 ## 1.5
 
 ### Features

--- a/scripts/lib/components/InstallmentsGenerator.js
+++ b/scripts/lib/components/InstallmentsGenerator.js
@@ -70,7 +70,16 @@ const DEFAULT_OPTIONS = {
 
     // allows provision of explicit mapping between payment schedule names
     // and corresponding DateCalc `increment` values
-    paymentScheduleToIncrement: {} // supply if defaults insufficient
+    paymentScheduleToIncrement: {}, // supply if defaults insufficient
+
+    /**
+     * Specifies the maximum number of Installments
+     *
+     * If set to a number E.g: 9, there will be max 9 installments generated.
+     *
+     * The default will be unlimited if not set.
+     */
+    maxInstallments: undefined
 };
 
 const DEFAULT_PAYMENT_SCHEDULE_TO_INCREMENT = {
@@ -219,7 +228,8 @@ class InstallmentsGenerator {
                     anchorTimestamp: this.options.remainderInstallmentsFirst ? term.endTimestamp
                         : term.startTimestamp,
                     returnIntervals: true,
-                    returnMetadata: true
+                    returnMetadata: true,
+                    maxCount: this.options.maxInstallments
                 });
 
             term.installments = span.sequence;

--- a/scripts/lib/utils/utils.js
+++ b/scripts/lib/utils/utils.js
@@ -1,3 +1,18 @@
+/**
+ * This function is for determining the generator options.
+ *
+ * It will get installments plugin data as an argument.
+ *
+ * This function can be updatable with different business logic by looking up the `data`
+ * and can return different options according to that logic.
+ *
+ * By default, it returns an empty object and doesn't change the default options.
+ */
+const determineInstallmentGeneratorOptions = (data) => {
+  return {};
+};
+
 module.exports = {
-    durationCalcMethod: (paymentScheduleName) => (paymentScheduleName === 'weekly' ? 'wholeDays' : 'months')
+  determineInstallmentGeneratorOptions,
+  durationCalcMethod: (paymentScheduleName) => (paymentScheduleName === 'weekly' ? 'wholeDays' : 'months')
 }

--- a/scripts/main/installments.js
+++ b/scripts/main/installments.js
@@ -1,8 +1,9 @@
 const { InstallmentsGenerator } = require('../lib/components/InstallmentsGenerator.js');
+const { determineInstallmentGeneratorOptions } = require('../lib/utils/utils.js');
 
 function createInstallments(data)
 {
-    return (new InstallmentsGenerator(data)).getInstallments();
+    return (new InstallmentsGenerator(data, determineInstallmentGeneratorOptions(data))).getInstallments();
 }
 
 module.exports = {

--- a/scripts/wrappers/partial-payment/installments.js
+++ b/scripts/wrappers/partial-payment/installments.js
@@ -1,5 +1,6 @@
 require("../../lib/utils/arrays.js");
 const { InstallmentsGenerator }= require("../../lib/components/InstallmentsGenerator.js");
+const { determineInstallmentGeneratorOptions } = require("../../lib/utils/utils.js");
 
 /**
  * Implements ability to handle partial payments, with dependency on aux data
@@ -13,7 +14,7 @@ const { InstallmentsGenerator }= require("../../lib/components/InstallmentsGener
  *  amounts being applied to subsequent installments until the remainder is exhausted.
  */
 function createInstallments(data) {
-    const generator = new InstallmentsGenerator(data);
+    const generator = new InstallmentsGenerator(data, determineInstallmentGeneratorOptions(data));
     const { installments } = generator.getInstallments();
 
     const partialPaymentInfo = socotraApi.getAuxData(data.policy.locator, 'partialPaymentInfo');


### PR DESCRIPTION
First of all thanks for the plugin implementations.

We are using the installments plugin in the Radity and we extend it a bit to fulfill our needs.

Made some generic updates to the plugin so that we can receive updates more easily, with less conflicts.

<hr />

9d12c7815658b7c9b5df391de211f3e19c24e027 is for determining the maximum number of installments that will be generated with the plugin. It only passes the option to the `getDateSequence` method as `maxCount` parameter.

<hr />

b7e4df7047c94267d11f8e4ab83bb5759a5b3b30 is for creating a center to determine the generator options outside of the wrapper or plugin scripts. By doing this we aim to have less conflict while we pull your updated codes and merge them with our business logic.
