### PR TITLE
Commission payments option

### DIFF
--- a/scripts/lib/components/InstallmentsGenerator.js
+++ b/scripts/lib/components/InstallmentsGenerator.js
@@ -224,7 +224,7 @@ class InstallmentsGenerator {
 
             term.installments = span.sequence;
 
-            for (let [i, inst] of term.installments.entries()) {;
+            for (let [i, inst] of term.installments.entries()) {
                 inst.dueTimestamp = inst.startTimestamp;
                 inst.invoiceItems = [];
                 inst.installmentFees = [];

--- a/scripts/lib/components/InstallmentsGenerator.js
+++ b/scripts/lib/components/InstallmentsGenerator.js
@@ -746,7 +746,7 @@ class InstallmentsGenerator {
      * Marks commission charges with `immediate` property in accordance with options
      */
     #markCommissionsAsImmediateIfPreferred() {
-        if (!this.options.commissionPayments === 'upFront') return;
+        if (this.options.commissionPayments !== 'upFront') return;
 
         for (let ch of this.data.charges) {
             if (ch.type === 'commission') {


### PR DESCRIPTION
The check on the `commissionPayments` was not working like defined in its description.

![image](https://user-images.githubusercontent.com/96168849/218129181-0032afc0-b7a0-4799-9ade-0a2fff773f3a.png)

It was not distributed commission by default, even if its value is `onInvoice`.

Now, by default it distributes the commission.

<hr />

Also removed some unnecessary semicolon.